### PR TITLE
Add `persistcache` library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	golang.org/x/crypto v0.1.0
 	golang.org/x/oauth2 v0.4.0
 	google.golang.org/api v0.103.0
+	gotest.tools v2.2.0+incompatible
 )
 
 require (

--- a/persistcache/README.md
+++ b/persistcache/README.md
@@ -1,0 +1,27 @@
+# Persisted Cache (persistcache)
+
+## Use-case
+
+This package implements a persistance cache. The main use-case is to store data on filesystem and
+provide access to it via API. Limitation of current implementation is that data should be represented
+as string. This was developed for configuration services feature in EVE. Since there is an option for 
+user to provide object to store via inline query, EVE has to store it even after reboot.
+
+## API & Usage
+
+Main structure is `pesistCache` outside of `persistcache` package it could be created via `Load` function:
+it is loads values from cache if they are present or created folder if there was none.
+`persistCache` structure has 3 operations:
+
+- *Get* value from in-memory cache
+- *Put* value to in-memory cache and store it in filesystem
+- *Delete* value from in-memory cache and filesystem
+
+Note that although technically you can use two different objects to access same directory, it is not intended
+library behaviour.
+
+## Design decisions
+
+### Why we are storing separate files and not saving whole structure as file?
++ If objects stored are large it takes less time to save/update them and less code
++ Access to cache file is easier

--- a/persistcache/README.md
+++ b/persistcache/README.md
@@ -25,3 +25,7 @@ library behaviour.
 ### Why we are storing separate files and not saving whole structure as file?
 + If objects stored are large it takes less time to save/update them and less code
 + Access to cache file is easier
+
+### Why store `string` and not `interface{}`
+This way library user bears responsibility of marshalling and unmarshalling object on his side, keeping this
+library simple

--- a/persistcache/persistcache.go
+++ b/persistcache/persistcache.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2023 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package persistcache
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+type persistCache struct {
+	cache map[string]string
+	root  string
+}
+
+const FILE_MASK = 0755
+
+// Load values from cache or creates path if there's none
+func Load(path string) (*persistCache, error) {
+	pc := &persistCache{}
+	pc.root = path
+	pc.cache = make(map[string]string)
+
+	if _, err := os.Stat(pc.root); os.IsNotExist(err) {
+		os.MkdirAll(pc.root, FILE_MASK)
+		return pc, nil
+	}
+
+	err := filepath.WalkDir(pc.root, func(path string, di fs.DirEntry, err error) error {
+		// We skip all directories
+		if di.IsDir() {
+			return nil
+		}
+
+		val, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		pc.cache[di.Name()] = string(val)
+
+		return nil
+	})
+	return pc, err
+}
+
+// Get value from cache
+func (pc *persistCache) Get(key string) (string, bool) {
+	val, ok := pc.cache[key]
+	return val, ok
+}
+
+// Create or update value in in-memory cache and filesystem
+func (pc *persistCache) Put(key string, val string) (string, error) {
+	pc.cache[key] = val
+
+	// save file
+	filepath := filepath.Join(pc.root, key)
+	f, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, FILE_MASK)
+	if err != nil {
+		return "", err
+	}
+	f.WriteString(val)
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+
+	return filepath, nil
+}
+
+// Remove element from cache and filesystem
+func (pc *persistCache) Delete(key string) error {
+	delete(pc.cache, key)
+	return os.Remove(filepath.Join(pc.root, key))
+}

--- a/persistcache/persistcache_test.go
+++ b/persistcache/persistcache_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2023 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package persistcache_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lf-edge/eve-libs/persistcache"
+	"gotest.tools/assert"
+)
+
+type persistObj struct {
+	Name string
+	Val  string
+}
+
+func TestPut(test *testing.T) {
+	path, _ := os.Getwd()
+	persistCacheFolder := filepath.Join(path, "testPersist/")
+	defer os.RemoveAll(persistCacheFolder)
+
+	pc, _ := persistcache.Load(persistCacheFolder)
+
+	// Create
+	obj1 := persistObj{
+		Name: "object1",
+		Val:  "123",
+	}
+	pc.Put(obj1.Name, obj1.Val)
+	expected, _ := pc.Get(obj1.Name)
+	assert.Equal(test, obj1.Val, expected)
+
+	// Update
+	newVal := "320"
+	pc.Put(obj1.Name, newVal)
+	expected, _ = pc.Get(obj1.Name)
+	assert.Equal(test, newVal, expected)
+}
+
+func TestDelete(test *testing.T) {
+	path, _ := os.Getwd()
+	persistCacheFolder := filepath.Join(path, "testPersist/")
+	defer os.RemoveAll(persistCacheFolder)
+
+	obj1 := persistObj{
+		Name: "object1",
+		Val:  "123",
+	}
+
+	pc, _ := persistcache.Load(persistCacheFolder)
+	pc.Put(obj1.Name, obj1.Val)
+
+	val, _ := pc.Get(obj1.Name)
+	assert.Equal(test, obj1.Val, val)
+
+	pc.Delete(obj1.Name)
+
+	val, _ = pc.Get(obj1.Name)
+	assert.Equal(test, "", val)
+}
+
+func TestLoad(test *testing.T) {
+	path, _ := os.Getwd()
+	persistCacheFolder := filepath.Join(path, "testPersist/")
+	defer os.RemoveAll(persistCacheFolder)
+
+	obj1 := persistObj{
+		Name: "object1",
+		Val:  "123",
+	}
+	obj2 := persistObj{
+		Name: "object2",
+		Val:  "bazinga",
+	}
+
+	pc, _ := persistcache.Load(persistCacheFolder)
+
+	pc.Put(obj1.Name, obj1.Val)
+	pc.Put(obj2.Name, obj2.Val)
+
+	val, _ := pc.Get(obj1.Name)
+	assert.Equal(test, obj1.Val, val)
+	val, _ = pc.Get(obj2.Name)
+	assert.Equal(test, obj2.Val, val)
+
+	// Check that we can access same files from new object
+	pc2, _ := persistcache.Load(persistCacheFolder)
+
+	val, _ = pc2.Get(obj1.Name)
+	assert.Equal(test, obj1.Val, val)
+
+	val, _ = pc2.Get(obj2.Name)
+	assert.Equal(test, obj2.Val, val)
+}

--- a/persistcache/persistcache_test.go
+++ b/persistcache/persistcache_test.go
@@ -38,6 +38,11 @@ func TestPut(test *testing.T) {
 	pc.Put(obj1.Name, newVal)
 	expected, _ = pc.Get(obj1.Name)
 	assert.Equal(test, newVal, expected)
+
+	// Try to insert malicious value
+	expected, err := pc.Put("../../../../etc/passwd", "myNewPassword")
+	assert.Equal(test, &persistcache.InvalidKeyError{}, err)
+	assert.Equal(test, "", expected)
 }
 
 func TestDelete(test *testing.T) {

--- a/persistcache/persistcache_test.go
+++ b/persistcache/persistcache_test.go
@@ -39,9 +39,14 @@ func TestPut(test *testing.T) {
 	expected, _ = pc.Get(obj1.Name)
 	assert.Equal(test, newVal, expected)
 
-	// Try to insert malicious value
+	// Try to insert malicious key
 	expected, err := pc.Put("../../../../etc/passwd", "myNewPassword")
 	assert.Equal(test, &persistcache.InvalidKeyError{}, err)
+	assert.Equal(test, "", expected)
+
+	// Try to insert empty value
+	expected, err = pc.Put("dummy", "")
+	assert.Equal(test, &persistcache.InvalidValueError{}, err)
 	assert.Equal(test, "", expected)
 }
 


### PR DESCRIPTION
This is a part of configuration services implementation on EVE side. This library is needed to store opaque envelopes, which are defined inline in query. We need to store them so that they will be accessible even after EVE reboot

There's lazy initialisation ideally to be done (we don't actually access all keys value), but I'm not sure I'll do it in first case 