### PR TITLE
remove external website dependencies for unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/Azure/azure-storage-blob-go v0.15.0
 	github.com/aws/aws-sdk-go v1.35.35
 	github.com/google/go-containerregistry v0.6.0
+	github.com/gorilla/mux v1.7.3
 	github.com/pkg/sftp v1.12.0
 	golang.org/x/crypto v0.1.0
 	golang.org/x/oauth2 v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -432,6 +432,7 @@ github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3i
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=


### PR DESCRIPTION
This is a follow-up to #4. It does not change the actual application code _at all_. It improves the http tests in the following ways:

- remove any dependency on external sites for testing; where Web servers are needed, use go `httptest` package
- create and remove files at will for those tests
- simplify some common activities into funcs
- reorder and rename the parameters to some utility functions to make them easier to understand and more logical in ordering
- add comments to some of the funcs, so future users can know what they are for
- check the results of upload and download to see that file contents actually match

