### PR TITLE
zedUpload/timeoutreader: fix timer leak which causes OOM

### DIFF
--- a/zedUpload/httputil/timeoutreader.go
+++ b/zedUpload/httputil/timeoutreader.go
@@ -32,10 +32,14 @@ func (r *TimeoutReader) Read(p []byte) (int, error) {
 		n, err = r.reader.Read(p)
 		c <- 0
 	}()
+
+	timer := time.NewTimer(r.timeout)
+	defer timer.Stop()
+
 	select {
 	case <-c:
 		return n, err
-	case <-time.After(r.timeout):
+	case <-timer.C:
 		return 0, &ErrTimeout{}
 	}
 }


### PR DESCRIPTION
Patch fixes very subtle memory leak which is very well explained here: https://arangodb.com/2020/09/a-story-of-a-memory-leak-in-go-how-to-properly-use-time-after/

The problem is easy to reproduce: deploy Vm application with the huge image (~10Gb) and monitor the zedbox process on RSS value while image is downloading: RSS reaches ~800Mb and zedbox is killed by the OOM.

Thanks to recently introduced go tracing in pillar (the `eve http-debug` feature), the memory leak was easy to catch.

Kudos to @rene and @christoph-zededa for helping to reproduce, catch and debug the issue.

Likely new patches with similar fixes will follow, because similar code pattern is used in many places.

@eriknordmark @deitch Please review.