### PR TITLE
Avoid hanging statsUpdater go routines

### DIFF
--- a/zedUpload/datastore.go
+++ b/zedUpload/datastore.go
@@ -279,7 +279,9 @@ func reqPostSize(req *DronaRequest, dronaCtx *DronaCtx, stats types.UpdateStats)
 	dronaCtx.postSize(req, stats.Size, stats.Asize)
 }
 
-func statsUpdater(req *DronaRequest, dronaCtx *DronaCtx, prgNotif types.StatsNotifChan) {
+func statsUpdater(wg *sync.WaitGroup, req *DronaRequest, dronaCtx *DronaCtx,
+	prgNotif types.StatsNotifChan) {
+	defer wg.Done()
 	ticker := time.NewTicker(StatsUpdateTicker)
 	defer ticker.Stop()
 	var newStats, stats types.UpdateStats

--- a/zedUpload/datastore_gs.go
+++ b/zedUpload/datastore_gs.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/lf-edge/eve-libs/nettrace"
@@ -109,10 +110,13 @@ func (ep *GsTransportMethod) processGSUpload(req *DronaRequest) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {
-		go statsUpdater(req, ep.ctx, prgChan)
+		wg.Add(1)
+		go statsUpdater(&wg, req, ep.ctx, prgChan)
 	}
 	hClient, err := ep.hClientWrap.unwrap()
 	if err != nil {
@@ -150,10 +154,13 @@ func (ep *GsTransportMethod) processGSDownload(req *DronaRequest) (int, error) {
 		}
 	}
 
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {
-		go statsUpdater(req, ep.ctx, prgChan)
+		wg.Add(1)
+		go statsUpdater(&wg, req, ep.ctx, prgChan)
 	}
 
 	err = s.DownloadFile(req.objloc, ep.bucket, req.name, req.sizelimit, prgChan)
@@ -193,10 +200,13 @@ func (ep *GsTransportMethod) processGSList(req *DronaRequest) ([]string, int, er
 	var csize int
 	var s []string
 
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {
-		go statsUpdater(req, ep.ctx, prgChan)
+		wg.Add(1)
+		go statsUpdater(&wg, req, ep.ctx, prgChan)
 	}
 	hClient, err := ep.hClientWrap.unwrap()
 	if err != nil {

--- a/zedUpload/datastore_http.go
+++ b/zedUpload/datastore_http.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/lf-edge/eve-libs/nettrace"
@@ -111,10 +112,13 @@ func (ep *HttpTransportMethod) GetNetTrace(description string) (
 // File upload to HTTP Datastore
 func (ep *HttpTransportMethod) processHttpUpload(req *DronaRequest) (error, int) {
 	postUrl := ep.hurl + "/" + ep.path
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {
-		go statsUpdater(req, ep.ctx, prgChan)
+		wg.Add(1)
+		go statsUpdater(&wg, req, ep.ctx, prgChan)
 	}
 	hClient, err := ep.hClientWrap.unwrap()
 	if err != nil {
@@ -131,10 +135,13 @@ func (ep *HttpTransportMethod) processHttpDownload(req *DronaRequest) (error, in
 	if ep.hurl != "" {
 		file = ep.hurl + "/" + ep.path + "/" + req.name
 	}
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {
-		go statsUpdater(req, ep.ctx, prgChan)
+		wg.Add(1)
+		go statsUpdater(&wg, req, ep.ctx, prgChan)
 	}
 	hClient, err := ep.hClientWrap.unwrap()
 	if err != nil {
@@ -153,10 +160,13 @@ func (ep *HttpTransportMethod) processHttpDelete(req *DronaRequest) error {
 // File list from HTTP Datastore
 func (ep *HttpTransportMethod) processHttpList(req *DronaRequest) ([]string, error) {
 	listUrl := ep.hurl + "/" + ep.path
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {
-		go statsUpdater(req, ep.ctx, prgChan)
+		wg.Add(1)
+		go statsUpdater(&wg, req, ep.ctx, prgChan)
 	}
 	hClient, err := ep.hClientWrap.unwrap()
 	if err != nil {
@@ -173,10 +183,13 @@ func (ep *HttpTransportMethod) processHttpObjectMetaData(req *DronaRequest) (err
 	if ep.hurl != "" {
 		file = ep.hurl + "/" + ep.path + "/" + req.name
 	}
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {
-		go statsUpdater(req, ep.ctx, prgChan)
+		wg.Add(1)
+		go statsUpdater(&wg, req, ep.ctx, prgChan)
 	}
 	hClient, err := ep.hClientWrap.unwrap()
 	if err != nil {

--- a/zedUpload/datastore_oci.go
+++ b/zedUpload/datastore_oci.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/lf-edge/eve-libs/nettrace"
@@ -131,10 +132,13 @@ func (ep *OCITransportMethod) processDownload(req *DronaRequest) (int64, string,
 	if ep.registry == "" {
 		return size, "", fmt.Errorf("cannot download from blank registry")
 	}
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {
-		go statsUpdater(req, ep.ctx, prgChan)
+		wg.Add(1)
+		go statsUpdater(&wg, req, ep.ctx, prgChan)
 	}
 	hClient, err := ep.hClientWrap.unwrap()
 	if err != nil {
@@ -155,10 +159,13 @@ func (ep *OCITransportMethod) processDelete(req *DronaRequest) error {
 
 // processList list tags for a given image in OCI registry
 func (ep *OCITransportMethod) processList(req *DronaRequest) ([]string, error) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {
-		go statsUpdater(req, ep.ctx, prgChan)
+		wg.Add(1)
+		go statsUpdater(&wg, req, ep.ctx, prgChan)
 	}
 	hClient, err := ep.hClientWrap.unwrap()
 	if err != nil {
@@ -178,10 +185,13 @@ func (ep *OCITransportMethod) processObjectMetaData(req *DronaRequest) (string, 
 	if ep.registry == "" {
 		return imageSha256, size, fmt.Errorf("cannot download from blank registry")
 	}
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {
-		go statsUpdater(req, ep.ctx, prgChan)
+		wg.Add(1)
+		go statsUpdater(&wg, req, ep.ctx, prgChan)
 	}
 	hClient, err := ep.hClientWrap.unwrap()
 	if err != nil {


### PR DESCRIPTION
After every DronaEndPoint Action (download, upload, list, etc.), statsUpdater Go routine remains blocked and hanging forever.

This is how it happens:

1. DronaEndPoint Action starts statsUpdater and passes it a channel prgChan with updates to publish
2. statsUpdater publishes progress updates to the listener (e.g. downloader microservice in EVE)
3. When Action ends, it closes prgChan and immediately sends update to the listener with processed=true (Action ended)
4. Listener stops listening for further updates (after seeing processed=true)
5. statsUpdater tries to send one last update but nobody is listening

With many operations (e.g. periodically repeated failed download), many hanging Go routines will mount up and consume some resources.

The fix is to have the Action wait for the statsUpdater to send the last update and exit (after closing the prgChan), before informing the listener that the action ended.