### PR TITLE
Partial Writes shouldn't log buffer

### DIFF
--- a/zedUpload/azureutil/azure.go
+++ b/zedUpload/azureutil/azure.go
@@ -67,7 +67,7 @@ func (c *sectionWriter) Write(p []byte) (int, error) {
 	}
 
 	if len(p) > n {
-		return n, fmt.Errorf("not enough space for %d bytes: %d", p, n)
+		return n, fmt.Errorf("partial write %d bytes, %d bytes remaining", n, len(slice)-n)
 	}
 
 	c.part.Size = c.part.Size + int64(n)


### PR DESCRIPTION
Just note the difference in byte count of the write, the entire buffer can lead to ~8k character log entries.