### PR TITLE
zedUpload: Fallback to maxsize on HEAD request error

### DIFF
--- a/zedUpload/ociutil/oci.go
+++ b/zedUpload/ociutil/oci.go
@@ -137,7 +137,9 @@ func PullBlob(registry, repo, hash, localFile, username, apiKey string, maxsize 
 		}
 		size, err = layer.Size()
 		if err != nil {
-			return 0, "", fmt.Errorf("could not get layer size %s: %v", ref.String(), err)
+			// Registry didn't reply correctly the HEAD request for size, fallback to the maxsize
+			size = maxsize
+			logrus.Errorf("could not get layer size %s: %v, trying maxsize %d ...", ref.String(), err, size)
 		}
 	}
 


### PR DESCRIPTION
Some registries, like AWS ECR do not respect the OCI spec regarding HEAD requests to get the size of a layer (blob), leading to errors like the following:

error could not get layer size XXXXX: HEAD XXXXX: unexpected status code 403 Forbidden (HEAD responses have no body, use GET for details)

This commit provides a workaround, falling back size to maxsize if the layer's size cannot be retrieved. This fix was tested with the faulty registry and it works.

Thanks @deitch for helping debug this issue.