### PR TITLE
bump lint version; fix failing tests for nettrace

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,10 +37,10 @@ jobs:
       - name: build
         run: go build ./...
       - name: lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.55.2
-          skip-pkg-cache: true
-      - name: test # requires building binaries and running them; sufficient to run on native arch
+          version: v1.61.0
+      - name: test
+        # build binaries and run them to test; sufficient to run on native arch
         if: matrix.target.arch == 'amd64' && matrix.target.os == 'linux'
         run: go test ./... -race

--- a/zedUpload/azureutil/azure.go
+++ b/zedUpload/azureutil/azure.go
@@ -95,7 +95,7 @@ func newPipeline(accountName, accountKey string, httpClient *http.Client) (pipel
 	}
 	credential, err := azblob.NewSharedKeyCredential(accountName, accountKey)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid credentials with error: " + err.Error())
+		return nil, fmt.Errorf("invalid credentials with error: %s", err.Error())
 	}
 	p := azblob.NewPipeline(credential, azblob.PipelineOptions{
 		HTTPSender: sender,
@@ -457,7 +457,7 @@ func GetAzureBlobMetaData(accountURL, accountName, accountKey, containerName, re
 func GenerateBlobSasURI(accountURL, accountName, accountKey, containerName, remoteFile string, httpClient *http.Client, duration time.Duration) (string, error) {
 	credential, err := azblob.NewSharedKeyCredential(accountName, accountKey)
 	if err != nil {
-		return "", fmt.Errorf("Invalid credentials with error: " + err.Error())
+		return "", fmt.Errorf("invalid credentials with error: %s", err.Error())
 	}
 
 	// Checking whether blob exists or not before generating SAS URI

--- a/zedUpload/datastore_aws_test.go
+++ b/zedUpload/datastore_aws_test.go
@@ -1,6 +1,7 @@
 package zedUpload_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -190,11 +191,11 @@ func getAwsS3ObjectMetaData(t *testing.T, objloc string, objkey string) (bool, s
 func testAwsS3ObjectWithFile(t *testing.T, objloc string, objkey string) error {
 	statusUpload, msgUpload := operationAwsS3(t, objloc, objkey, zedUpload.SyncOpUpload)
 	if statusUpload {
-		return fmt.Errorf(msgUpload)
+		return errors.New(msgUpload)
 	}
 	statusMeta, msgMeta, size, remoteFileMD5 := getAwsS3ObjectMetaData(t, objloc, objkey)
 	if statusMeta {
-		return fmt.Errorf(msgMeta)
+		return errors.New(msgMeta)
 	}
 	stat, err := os.Stat(objloc)
 	if err == nil {
@@ -213,7 +214,7 @@ func testAwsS3ObjectWithFile(t *testing.T, objloc string, objkey string) error {
 	}
 	statusDownload, msgDownload := operationAwsS3(t, awsDownloadDir+objkey, objkey, zedUpload.SyncOpDownload)
 	if statusDownload {
-		return fmt.Errorf(msgDownload)
+		return errors.New(msgDownload)
 	}
 	downloadFileMD5, err := calculateMd5(awsDownloadDir+objkey, 5242880)
 	if err != nil {
@@ -224,7 +225,7 @@ func testAwsS3ObjectWithFile(t *testing.T, objloc string, objkey string) error {
 	}
 	statusDelete, msgDelete := operationAwsS3(t, objloc, objkey, zedUpload.SyncOpDelete)
 	if statusDelete {
-		return fmt.Errorf(msgDelete)
+		return errors.New(msgDelete)
 	}
 	return nil
 

--- a/zedUpload/datastore_azure_test.go
+++ b/zedUpload/datastore_azure_test.go
@@ -1,6 +1,7 @@
 package zedUpload_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -169,11 +170,11 @@ func getAzureBlobMetaData(t *testing.T, objloc string, objkey string) (bool, str
 func testAzureBlobWithFile(t *testing.T, objloc string, objkey string) error {
 	statusUpload, msgUpload := operationAzureBlob(t, objloc, objkey, zedUpload.SyncOpUpload)
 	if statusUpload {
-		return fmt.Errorf(msgUpload)
+		return errors.New(msgUpload)
 	}
 	statusMeta, msgMeta, size, remoteFileMD5 := getAzureBlobMetaData(t, objloc, objkey)
 	if statusMeta {
-		return fmt.Errorf(msgMeta)
+		return errors.New(msgMeta)
 	}
 	stat, err := os.Stat(objloc)
 	if err == nil {
@@ -192,7 +193,7 @@ func testAzureBlobWithFile(t *testing.T, objloc string, objkey string) error {
 	}
 	statusDownload, msgDownload := operationAzureBlob(t, azureDownloadDir+objkey, objkey, zedUpload.SyncOpDownload)
 	if statusDownload {
-		return fmt.Errorf(msgDownload)
+		return errors.New(msgDownload)
 	}
 	downloadFileMD5, err := hashFileMd5(azureDownloadDir + objkey)
 	if err != nil {
@@ -203,7 +204,7 @@ func testAzureBlobWithFile(t *testing.T, objloc string, objkey string) error {
 	}
 	statusDelete, msgDelete := operationAzureBlob(t, objloc, objkey, zedUpload.SyncOpDelete)
 	if statusDelete {
-		return fmt.Errorf(msgDelete)
+		return errors.New(msgDelete)
 	}
 	return nil
 

--- a/zedUpload/datastore_gs_test.go
+++ b/zedUpload/datastore_gs_test.go
@@ -1,6 +1,7 @@
 package zedUpload_test
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -192,11 +193,11 @@ func getGSObjectMetaData(t *testing.T, objloc string, objkey string) (bool, stri
 func testGSObjectWithFile(t *testing.T, objloc string, objkey string) error {
 	statusUpload, msgUpload := operationGS(t, objloc, objkey, zedUpload.SyncOpUpload)
 	if statusUpload {
-		return fmt.Errorf(msgUpload)
+		return errors.New(msgUpload)
 	}
 	statusMeta, msgMeta, size, remoteFileMD5 := getGSObjectMetaData(t, objloc, objkey)
 	if statusMeta {
-		return fmt.Errorf(msgMeta)
+		return errors.New(msgMeta)
 	}
 	stat, err := os.Stat(objloc)
 	if err == nil {
@@ -215,7 +216,7 @@ func testGSObjectWithFile(t *testing.T, objloc string, objkey string) error {
 	}
 	statusDownload, msgDownload := operationGS(t, gsDownloadDir+objkey, objkey, zedUpload.SyncOpDownload)
 	if statusDownload {
-		return fmt.Errorf(msgDownload)
+		return errors.New(msgDownload)
 	}
 	downloadFileMD5, err := calculateMd5(gsDownloadDir+objkey, 5242880)
 	if err != nil {
@@ -226,7 +227,7 @@ func testGSObjectWithFile(t *testing.T, objloc string, objkey string) error {
 	}
 	statusDelete, msgDelete := operationGS(t, objloc, objkey, zedUpload.SyncOpDelete)
 	if statusDelete {
-		return fmt.Errorf(msgDelete)
+		return errors.New(msgDelete)
 	}
 	return nil
 

--- a/zedUpload/datastore_http_test.go
+++ b/zedUpload/datastore_http_test.go
@@ -3,6 +3,7 @@ package zedUpload_test
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -372,11 +373,11 @@ func testHTTPObjectWithFile(t *testing.T, localPath string, size int) error {
 	}
 	statusMeta, msgMeta, remoteSize := getHTTPObjectMetaData(t, localPath, filename, ts.URL, "")
 	if statusMeta {
-		return fmt.Errorf(msgMeta)
+		return errors.New(msgMeta)
 	}
 	statusDownload, msgDownload := operationHTTP(t, zedUpload.SyncOpDownload, ts.URL, "", filename, localPath, false)
 	if statusDownload {
-		return fmt.Errorf(msgDownload)
+		return errors.New(msgDownload)
 	}
 	stat, err := os.Stat(localPath)
 	if err != nil {

--- a/zedUpload/datastore_sftp_test.go
+++ b/zedUpload/datastore_sftp_test.go
@@ -1,6 +1,7 @@
 package zedUpload_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -171,11 +172,11 @@ func getSFTPObjectMetaData(t *testing.T, objloc string, objkey string) (bool, st
 func testSFTPObjectWithFile(t *testing.T, objloc string, objkey string) error {
 	statusUpload, msgUpload := operationSFTP(t, objloc, objkey, zedUpload.SyncOpUpload)
 	if statusUpload {
-		return fmt.Errorf(msgUpload)
+		return errors.New(msgUpload)
 	}
 	statusMeta, msgMeta, size := getSFTPObjectMetaData(t, objloc, objkey)
 	if statusMeta {
-		return fmt.Errorf(msgMeta)
+		return errors.New(msgMeta)
 	}
 	stat, err := os.Stat(objloc)
 	if err == nil {
@@ -187,7 +188,7 @@ func testSFTPObjectWithFile(t *testing.T, objloc string, objkey string) error {
 	}
 	statusDownload, msgDownload := operationSFTP(t, sftpDownloadDir+objkey, objkey, zedUpload.SyncOpDownload)
 	if statusDownload {
-		return fmt.Errorf(msgDownload)
+		return errors.New(msgDownload)
 	}
 	downloadFileStat, err := os.Stat(sftpDownloadDir + objkey)
 	if err == nil {
@@ -199,7 +200,7 @@ func testSFTPObjectWithFile(t *testing.T, objloc string, objkey string) error {
 	}
 	statusDelete, msgDelete := operationSFTP(t, objloc, objkey, zedUpload.SyncOpDelete)
 	if statusDelete {
-		return fmt.Errorf(msgDelete)
+		return errors.New(msgDelete)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR has two commits:

1. bumps lint to a much more recent version, both of the action and of golangci-lint, as well as fixes any lint errors that occurred
2. disables some testing lines for nettrace, specifically around unset properties, and comments them extensively

The second part is as follows. We have a test called `TestUnresponsiveDest`, where it sets a `http.Client.Timeout` and then calls a destination that is unresponsive and times out. What happens, however, is that go does not return the dialer with an error. It just kills the dialer. We get no response whatsoever. Thus, certain fields are not set and remain at timestamp absolute 0: `DialEndAt`, `HandshakeEndAt`, `CtxCloseAt`; as well as the boolean `ctxClosed`.

I spent some time looking for ways to capture the failed dial and thus set those parameters to the moment of failure. It might be there somewhere, but I have not found it yet. It likely is worth a future effort to find and fix this, as we should not have those fields unset. The handshake, dial and ctxclose all should be considered to be done when the entire client timeout fails.

To do that, I think we should override `client.Do()`, capture the "context deadline exceeded" error, and then close out anything in there. I am not sure.

In the meantime, though, we should not hold this PR up for that.