### PR TITLE
Reduce nettrace memory usage by limiting in-memory metadata and offlo…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	golang.org/x/crypto v0.41.0
 	golang.org/x/oauth2 v0.30.0
 	google.golang.org/api v0.248.0
+	go.etcd.io/bbolt v1.3.5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -925,6 +925,7 @@ github.com/zeebo/errs v1.4.0 h1:XNdoD/RRMKP7HD0UhJnIzUy74ISdGGxURlYG8HSWSfM=
 github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=

--- a/nettrace/evictingmap.go
+++ b/nettrace/evictingmap.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nettrace
+
+import "sync"
+
+// evictingMap is a bounded, insertion-ordered in-memory store for recent
+// trace metadata (connections, dials, HTTP requests, etc.).
+//
+// Purpose:
+//   - Cap memory use by keeping only the most recent N items.
+//   - Preserve insertion order so the oldest item is evicted first.
+//
+// Behavior:
+//   - When capacity is reached, the oldest item is evicted.
+//   - Optionally, evicted items are batched and passed to a caller-provided
+//     flush function once a threshold is met. If no flush is configured,
+//     evicted items are simply dropped.
+//
+// How it’s used here (two modes):
+//   - In-memory mode (no WithBatchOffload):
+//     Everything stays in memory up to the set capacity.
+//     Evictions are dropped.
+//     GetTrace() reads directly from these in-memory structures.
+//   - Offload mode (WithBatchOffload enabled):
+//     The HTTP client offloads batches via a callback; this map is configured
+//     to avoid doing its own flushes.
+//     Any persistence (e.g., to BoltDB) is handled by the offload callback.
+
+type evictingMap struct {
+	store       map[TraceID]interface{}
+	order       []TraceID
+	limit       int
+	bucket      string
+	batchBuffer []finalizedTrace
+	mutex       sync.Mutex
+
+	flushThreshold int
+	flushFn        func(batch []finalizedTrace)
+}
+
+func newEvictingMap(limit int, bucket string, flushThreshold int, flushFn func([]finalizedTrace)) *evictingMap {
+	return &evictingMap{
+		store:          make(map[TraceID]interface{}),
+		order:          make([]TraceID, 0, limit),
+		limit:          limit,
+		bucket:         bucket,
+		flushThreshold: flushThreshold,
+		flushFn:        flushFn,
+	}
+}
+
+// Set inserts or updates a key. If capacity is exceeded, the oldest entry
+// is evicted. If a flushFn is configured, evicted items are batched and
+// flushed asynchronously once the flushThreshold is reached.
+func (m *evictingMap) Set(key TraceID, value interface{}) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if _, exists := m.store[key]; exists {
+		m.store[key] = value
+		return
+	}
+
+	// Evict if over limit
+	if m.limit > 0 && len(m.order) >= m.limit {
+		oldest := m.order[0]
+		m.order = m.order[1:]
+
+		oldVal := m.store[oldest]
+		delete(m.store, oldest)
+
+		// Only build/flush a batch if a flusher is actually configured.
+		if m.flushFn != nil {
+			m.batchBuffer = append(m.batchBuffer, finalizedTrace{
+				Bucket: m.bucket,
+				Key:    oldest,
+				Value:  oldVal,
+			})
+			// Flush if enough evictions accumulated
+			if m.flushThreshold > 0 && len(m.batchBuffer) >= m.flushThreshold {
+				batch := m.batchBuffer
+				m.batchBuffer = nil // clear before flushing
+				go m.flushFn(batch) // async flush
+			}
+		}
+	}
+
+	m.order = append(m.order, key)
+	m.store[key] = value
+}
+
+func (m *evictingMap) Len() int {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return len(m.store)
+}
+
+func (m *evictingMap) Get(key TraceID) (interface{}, bool) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	val, ok := m.store[key]
+	return val, ok
+}
+
+func (m *evictingMap) Delete(key TraceID) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if _, exists := m.store[key]; !exists {
+		return
+	}
+	delete(m.store, key)
+
+	for i, id := range m.order {
+		if id == key {
+			m.order = append(m.order[:i], m.order[i+1:]...)
+			break
+		}
+	}
+}

--- a/nettrace/httpbody.go
+++ b/nettrace/httpbody.go
@@ -17,15 +17,15 @@ type tracedHTTPBody struct {
 	length      uint64
 }
 
-// httpBodyTrace is used to signal how many bytes of HTTP req/resp body was already read.
-type httpBodyTrace struct {
-	httpReqID   TraceID
-	isRequest   bool
-	readBodyLen uint64
-	eof         bool
+// HTTPBodyTrace is used to signal how many bytes of HTTP req/resp body was already read.
+type HTTPBodyTrace struct {
+	HTTPReqID   TraceID
+	ISRequest   bool
+	ReadBodyLen uint64
+	EOF         bool
 }
 
-func (httpBodyTrace) isInternalNetTrace() {}
+func (HTTPBodyTrace) isInternalNetTrace() {}
 
 func newTracedHTTPBody(httpReqID TraceID, tracer networkTracer, isReq bool,
 	body io.ReadCloser) *tracedHTTPBody {
@@ -40,11 +40,11 @@ func newTracedHTTPBody(httpReqID TraceID, tracer networkTracer, isReq bool,
 func (hbt *tracedHTTPBody) Read(p []byte) (n int, err error) {
 	n, err = hbt.wrappedBody.Read(p)
 	hbt.length += uint64(n)
-	hbt.tracer.publishTrace(httpBodyTrace{
-		httpReqID:   hbt.httpReqID,
-		isRequest:   hbt.isRequest,
-		readBodyLen: hbt.length,
-		eof:         err == io.EOF,
+	hbt.tracer.publishTrace(HTTPBodyTrace{
+		HTTPReqID:   hbt.httpReqID,
+		ISRequest:   hbt.isRequest,
+		ReadBodyLen: hbt.length,
+		EOF:         err == io.EOF,
 	})
 	return n, err
 }

--- a/nettrace/nettrace.go
+++ b/nettrace/nettrace.go
@@ -89,6 +89,8 @@ type NetTrace struct {
 	TraceBeginAt Timestamp `json:"traceBeginAt"`
 	// TraceEndAt : time (relative to TraceBeginAt) when the tracing ended.
 	TraceEndAt Timestamp `json:"traceEndAt"`
+	// SessionUUID : unique identifier of the trace.
+	SessionUUID string `json:"uuid"`
 	// Dials : all attempts to establish connection with a remote endpoint.
 	Dials DialTraces `json:"dials"`
 	// TCPConns : all established or failed TCP connections.

--- a/nettraceStorage/client_sink.go
+++ b/nettraceStorage/client_sink.go
@@ -1,0 +1,276 @@
+// Copyright(c) 2025 Zededa, Inc.
+// All rights reserved.
+
+package nettraceStorage
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	nt "github.com/lf-edge/eve-libs/nettrace"
+	"go.etcd.io/bbolt"
+)
+
+// Bucket names (local to the sink; server does not persist)
+const (
+	bucketDials      = "dials"
+	bucketHTTPReqs   = "httpReqs"
+	bucketDNSQueries = "dnsQueries"
+	bucketTLSTuns    = "tlsTuns"
+	bucketTCPConns   = "tcpConns"
+	bucketUDPConns   = "udpConns"
+)
+
+// BoltBatchSink offloads batches of netTrace data into BoltDB
+// and supports exporting them into a single JSON file.
+type BoltBatchSink struct {
+	db   *bbolt.DB
+	path string
+}
+
+// NewBoltBatchSink opens/creates the BoltDB file and initializes buckets.
+func NewBoltBatchSink(dbPath string) (*BoltBatchSink, error) {
+	db, err := bbolt.Open(dbPath, 0o666, nil)
+	if err != nil {
+		return nil, err
+	}
+	s := &BoltBatchSink{db: db, path: dbPath}
+	if err := s.ensureBuckets(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return s, nil
+}
+
+// DeleteDBFile deletes the BoltDB file, based on session UUID
+func (s *BoltBatchSink) DeleteDBFile() error {
+	if s.db != nil {
+		_ = s.db.Close()
+	}
+	return os.Remove(s.path)
+}
+
+// Close closes the BoltDB.
+func (s *BoltBatchSink) Close() error {
+	// i want first to check if db is nil, and then close
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// Handler returns a nettrace.BatchCallback to pass into WithBatchOffload.
+func (s *BoltBatchSink) Handler() nt.BatchCallback { return s.HandleBatch }
+
+// HandleBatch persists a batch (upsert by TraceID). Safe to call concurrently.
+func (s *BoltBatchSink) HandleBatch(b nt.BatchSnapshot) {
+	_ = s.db.Update(func(tx *bbolt.Tx) error {
+		var err error
+		if err = s.upsertDials(tx, b.Dials); err != nil {
+			return err
+		}
+		if err = s.upsertHTTPReqs(tx, b.HTTPReqs); err != nil {
+			return err
+		}
+		if err = s.upsertDNS(tx, b.DNSQueries); err != nil {
+			return err
+		}
+		if err = s.upsertTLS(tx, b.TLSTunnels); err != nil {
+			return err
+		}
+		if err = s.upsertTCP(tx, b.TCPConns); err != nil {
+			return err
+		}
+		if err = s.upsertUDP(tx, b.UDPConns); err != nil {
+			return err
+		}
+		return err
+	})
+}
+
+// ExportToJSON writes one JSON file with everything persisted in Bbolt.
+// Pass the meta you receive from server.GetTrace (which now returns only NetTraceMeta + pcaps).
+func (s *BoltBatchSink) ExportToJSON(filePath string, meta nt.NetTrace) error {
+	f, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+
+	// open {
+	if _, err := f.Write([]byte(`{"description":`)); err != nil {
+		return err
+	}
+	if err := enc.Encode(meta.Description); err != nil {
+		return err
+	}
+	if _, err := f.Write([]byte(`,"traceBeginAt":`)); err != nil {
+		return err
+	}
+	if err := enc.Encode(meta.TraceBeginAt); err != nil {
+		return err
+	}
+	if _, err := f.Write([]byte(`,"traceEndAt":`)); err != nil {
+		return err
+	}
+	if err := enc.Encode(meta.TraceEndAt); err != nil {
+		return err
+	}
+
+	// sections streamed straight from Bolt
+	if err := s.streamBucketJSON(f, enc, `,"dials":[`, `]`, bucketDials); err != nil {
+		return err
+	}
+	if err := s.streamBucketJSON(f, enc, `,"tcpConns":[`, `]`, bucketTCPConns); err != nil {
+		return err
+	}
+	if err := s.streamBucketJSON(f, enc, `,"udpConns":[`, `]`, bucketUDPConns); err != nil {
+		return err
+	}
+	if err := s.streamBucketJSON(f, enc, `,"dnsQueries":[`, `]`, bucketDNSQueries); err != nil {
+		return err
+	}
+	if err := s.streamBucketJSON(f, enc, `,"httpRequests":[`, `]`, bucketHTTPReqs); err != nil {
+		return err
+	}
+	if err := s.streamBucketJSON(f, enc, `,"tlsTunnels":[`, `]`, bucketTLSTuns); err != nil {
+		return err
+	}
+
+	// close }
+	if _, err := f.Write([]byte(`}`)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ---------- internal helpers ----------
+
+func (s *BoltBatchSink) ensureBuckets() error {
+	return s.db.Update(func(tx *bbolt.Tx) error {
+		for _, name := range []string{
+			bucketDials,
+			bucketHTTPReqs,
+			bucketDNSQueries,
+			bucketTLSTuns,
+			bucketTCPConns,
+			bucketUDPConns,
+		} {
+			if _, err := tx.CreateBucketIfNotExists([]byte(name)); err != nil {
+				return fmt.Errorf("create bucket %s: %w", name, err)
+			}
+		}
+		return nil
+	})
+}
+
+func keyFor(id nt.TraceID) []byte { return []byte(fmt.Sprint(id)) }
+
+func putJSON(tx *bbolt.Tx, bucket string, key []byte, v interface{}) error {
+	b := tx.Bucket([]byte(bucket))
+	if b == nil {
+		var err error
+		b, err = tx.CreateBucketIfNotExists([]byte(bucket))
+		if err != nil {
+			return err
+		}
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return b.Put(key, data)
+}
+
+func (s *BoltBatchSink) upsertDials(tx *bbolt.Tx, items []nt.DialTrace) error {
+	for _, it := range items {
+		if err := putJSON(tx, bucketDials, keyFor(it.TraceID), it); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *BoltBatchSink) upsertHTTPReqs(tx *bbolt.Tx, items []nt.HTTPReqTrace) error {
+	for _, it := range items {
+		if err := putJSON(tx, bucketHTTPReqs, keyFor(it.TraceID), it); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *BoltBatchSink) upsertDNS(tx *bbolt.Tx, items []nt.DNSQueryTrace) error {
+	for _, it := range items {
+		if err := putJSON(tx, bucketDNSQueries, keyFor(it.TraceID), it); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *BoltBatchSink) upsertTLS(tx *bbolt.Tx, items []nt.TLSTunnelTrace) error {
+	for _, it := range items {
+		if err := putJSON(tx, bucketTLSTuns, keyFor(it.TraceID), it); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *BoltBatchSink) upsertTCP(tx *bbolt.Tx, items []nt.TCPConnTrace) error {
+	for _, it := range items {
+		if err := putJSON(tx, bucketTCPConns, keyFor(it.TraceID), it); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *BoltBatchSink) upsertUDP(tx *bbolt.Tx, items []nt.UDPConnTrace) error {
+	for _, it := range items {
+		if err := putJSON(tx, bucketUDPConns, keyFor(it.TraceID), it); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// streamBucketJSON re-encodes values so the output file is valid JSON.
+func (s *BoltBatchSink) streamBucketJSON(f *os.File, enc *json.Encoder, prefix, suffix, bucket string) error {
+	if _, err := f.Write([]byte(prefix)); err != nil {
+		return err
+	}
+	first := true
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket([]byte(bucket))
+		if b == nil {
+			return nil
+		}
+		return b.ForEach(func(k, v []byte) error {
+			if !first {
+				if _, err := f.Write([]byte(",")); err != nil {
+					return err
+				}
+			}
+			var data interface{}
+			if err := json.Unmarshal(v, &data); err != nil {
+				return err
+			}
+			if err := enc.Encode(data); err != nil {
+				return err
+			}
+			first = false
+			return nil
+		})
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write([]byte(suffix)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/zedUpload/commonutils.go
+++ b/zedUpload/commonutils.go
@@ -13,10 +13,14 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/lf-edge/eve-libs/nettrace"
+	ntStore "github.com/lf-edge/eve-libs/nettraceStorage"
 )
 
 const (
@@ -31,6 +35,8 @@ const (
 	idleConnTimeout       = 90 * time.Second
 	tlsHandshakeTimeout   = 10 * time.Second
 	expectContinueTimeout = 1 * time.Second
+	enableOffload         = true // or false
+
 )
 
 // ChunkData contains the details of Chunks being downloaded
@@ -76,8 +82,12 @@ type httpClientWrapper struct {
 	withTracing bool
 	tracingOpts []nettrace.TraceOpt
 	// initialization
-	initOnce sync.Once
-	initErr  error
+	initOnce        sync.Once
+	initErr         error
+	nettraceSink    *ntStore.BoltBatchSink
+	nettraceDirPath string
+
+	sessionUUID string
 }
 
 func (c *httpClientWrapper) unwrap() (*http.Client, error) {
@@ -93,6 +103,7 @@ func (c *httpClientWrapper) unwrap() (*http.Client, error) {
 			}
 			tlsConfig = &tls.Config{RootCAs: caCertPool}
 		}
+
 		if c.withTracing {
 			cfg := nettrace.HTTPClientCfg{
 				SourceIP:              c.srcIP,
@@ -105,26 +116,67 @@ func (c *httpClientWrapper) unwrap() (*http.Client, error) {
 				Proxy:                 http.ProxyURL(c.proxy),
 				TLSClientConfig:       tlsConfig,
 			}
-			traceClient, err := nettrace.NewHTTPClient(cfg, c.tracingOpts...)
+
+			// Ensure folder exists for the sink DB.
+			if err := os.MkdirAll(c.nettraceDirPath, 0o755); err != nil {
+				c.initErr = fmt.Errorf("create %s: %w", c.nettraceDirPath, err)
+				return
+			}
+
+			// Create session UUID (string) if not already set
+			if c.sessionUUID == "" {
+				c.sessionUUID = uuid.NewString()
+			}
+			opts := make([]nettrace.TraceOpt, 0, len(c.tracingOpts)+1)
+			opts = append(opts, c.tracingOpts...)
+
+			// enableOffload decides whether we stream to Bolt via WithBatchOffload.
+			// Drive this from your config/flag.
+			if enableOffload {
+				// Make sure the folder exists.
+				if err := os.MkdirAll(c.nettraceDirPath, 0o755); err != nil {
+					c.initErr = fmt.Errorf("create %s: %w", c.nettraceDirPath, err)
+					return
+				}
+				// One DB per session.
+				dbPath := fmt.Sprintf("%s/nettrace_%s.db", c.nettraceDirPath, c.sessionUUID)
+
+				sink, err := ntStore.NewBoltBatchSink(dbPath)
+				if err != nil {
+					c.initErr = fmt.Errorf("failed to create nettrace sink: %w", err)
+					return
+				}
+				c.nettraceSink = sink // remember it for later ExportToJSON / Close
+
+				// Add the batch offload so server streams to our sink.
+				opts = append(opts, &nettrace.WithBatchOffload{
+					Callback:          sink.Handler(),
+					Threshold:         1000, // per-map threshold
+					FinalFlushOnClose: true, // flush leftovers on Close()
+				})
+			} else {
+				// Pure in-memory path — no sink, no DB.
+				c.nettraceSink = nil
+			}
+
+			traceClient, err := nettrace.NewHTTPClient(cfg, c.sessionUUID, opts...)
 			if err != nil {
 				c.initErr = fmt.Errorf("failed to create HTTP client with tracing: %w", err)
+				traceClient.Close()
 				return
 			}
 			c.tracedClient = traceClient
+
 		} else {
+			// ----- existing non-tracing branch unchanged -----
 			dialer := &net.Dialer{
 				Timeout:   tcpHandshakeTimeout,
 				KeepAlive: tcpKeepAliveInterval,
 			}
 			if c.srcIP != nil {
-				// You also need to do this to make it work and not give you a
-				// "mismatched local address type ip"
-				// This will make the ResolveIPAddr a TCPAddr without needing to
-				// say what SRC port number to use.
 				localTCPAddr := &net.TCPAddr{IP: c.srcIP}
 				localUDPAddr := &net.UDPAddr{IP: c.srcIP}
-				resolverDial := func(
-					ctx context.Context, network, address string) (net.Conn, error) {
+				resolverDial := func(ctx context.Context, network, address string) (net.Conn, error) {
 					switch network {
 					case "udp", "udp4", "udp6":
 						d := net.Dialer{LocalAddr: localUDPAddr}
@@ -160,6 +212,7 @@ func (c *httpClientWrapper) unwrap() (*http.Client, error) {
 			c.client = client
 		}
 	})
+
 	if c.initErr != nil {
 		return nil, c.initErr
 	}
@@ -210,7 +263,33 @@ func (c *httpClientWrapper) getNetTrace(description string) (
 	if c.tracedClient == nil {
 		return nil, nil, nil
 	}
-	return c.tracedClient.GetTrace(description)
+
+	httpTrace, packetCapture, err := c.tracedClient.GetTrace(description)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	jsonPath := filepath.Join(c.nettraceDirPath, fmt.Sprintf("nettrace_%s.json", c.sessionUUID))
+	if c.nettraceSink != nil {
+		// Using batch-offload + Bolt sink
+		err = c.nettraceSink.ExportToJSON(jsonPath, httpTrace.NetTrace)
+	} else {
+		// No sink: dump the in-memory trace directly
+		err = c.tracedClient.ExportHTTPTraceToJSON(jsonPath, httpTrace)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Delete db file
+	if c.nettraceSink != nil {
+		if err := c.nettraceSink.DeleteDBFile(); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	httpTrace.SessionUUID = c.sessionUUID
+	return httpTrace, packetCapture, err
 }
 
 func (c *httpClientWrapper) close() error {

--- a/zedUpload/datastore.go
+++ b/zedUpload/datastore.go
@@ -174,7 +174,7 @@ type SyncerDestOption func(endpoint DronaEndPoint) error
 
 // NewSyncerDest add another location end point to syncer.
 // The options are passed directly to the specific transport and should match its type.
-func (ctx *DronaCtx) NewSyncerDest(tr SyncTransportType, UrlOrRegion, PathOrBkt string, auth *AuthInput, opts ...SyncerDestOption) (DronaEndPoint, error) {
+func (ctx *DronaCtx) NewSyncerDest(tr SyncTransportType, UrlOrRegion, nettraceDirPATH, PathOrBkt string, auth *AuthInput, opts ...SyncerDestOption) (DronaEndPoint, error) {
 	var endpoint DronaEndPoint
 	switch tr {
 	case SyncAwsTr:
@@ -184,6 +184,7 @@ func (ctx *DronaCtx) NewSyncerDest(tr SyncTransportType, UrlOrRegion, PathOrBkt 
 			syncEp.apiKey = auth.Password
 		}
 		syncEp.hClientWrap = &httpClientWrapper{}
+		syncEp.hClientWrap.nettraceDirPath = nettraceDirPATH
 		syncEp.failPostTime = time.Now()
 		endpoint = syncEp
 	case SyncAzureTr:
@@ -194,6 +195,7 @@ func (ctx *DronaCtx) NewSyncerDest(tr SyncTransportType, UrlOrRegion, PathOrBkt 
 			syncEp.acKey = auth.Password
 		}
 		syncEp.hClientWrap = &httpClientWrapper{}
+		syncEp.hClientWrap.nettraceDirPath = nettraceDirPATH
 		syncEp.failPostTime = time.Now()
 		endpoint = syncEp
 	case SyncHttpTr:
@@ -202,6 +204,7 @@ func (ctx *DronaCtx) NewSyncerDest(tr SyncTransportType, UrlOrRegion, PathOrBkt 
 			syncEp.authType = auth.AuthType
 		}
 		syncEp.hClientWrap = &httpClientWrapper{}
+		syncEp.hClientWrap.nettraceDirPath = nettraceDirPATH
 		syncEp.failPostTime = time.Now()
 		endpoint = syncEp
 	case SyncSftpTr:
@@ -221,6 +224,7 @@ func (ctx *DronaCtx) NewSyncerDest(tr SyncTransportType, UrlOrRegion, PathOrBkt 
 			syncEp.apiKey = auth.Password
 		}
 		syncEp.hClientWrap = &httpClientWrapper{}
+		syncEp.hClientWrap.nettraceDirPath = nettraceDirPATH
 		syncEp.failPostTime = time.Now()
 		endpoint = syncEp
 	case SyncGSTr:
@@ -230,6 +234,7 @@ func (ctx *DronaCtx) NewSyncerDest(tr SyncTransportType, UrlOrRegion, PathOrBkt 
 			syncEp.apiKey = auth.Password
 		}
 		syncEp.hClientWrap = &httpClientWrapper{}
+		syncEp.hClientWrap.nettraceDirPath = nettraceDirPATH
 		syncEp.failPostTime = time.Now()
 		endpoint = syncEp
 	default:

--- a/zedUpload/datastore_aws_test.go
+++ b/zedUpload/datastore_aws_test.go
@@ -12,6 +12,7 @@ import (
 const (
 	awsUploadFile  = uploadFile
 	awsDownloadDir = "./test/output/awsDownload/"
+	nettraceFolder = "./test/output/nettrace"
 )
 
 var (
@@ -28,6 +29,9 @@ func TestAwsS3Datastore(t *testing.T) {
 	}
 	if err := os.MkdirAll(awsDownloadDir, 0755); err != nil {
 		t.Fatalf("unable to make download directory: %v", err)
+	}
+	if err := os.MkdirAll(nettraceFolder, 0755); err != nil {
+		t.Fatalf("unable to make nettrace log directory: %v", err)
 	}
 	if awsBucket != "" && key != "" && secret != "" && awsRegion != "" {
 		t.Run("API", testAwsS3DatastoreAPI)
@@ -46,7 +50,7 @@ func operationAwsS3(t *testing.T, objloc string, objkey string, operation zedUpl
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAwsTr, awsRegion, awsBucket, awsAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAwsTr, awsRegion, nettraceFolder, awsBucket, awsAuth)
 	if err == nil && dEndPoint != nil {
 		// create Request
 		req := dEndPoint.NewRequest(operation, objkey, objloc, 0, true, respChan)
@@ -83,7 +87,7 @@ func operationAwsS3Negative(t *testing.T, s3Key string, s3Secret string, operati
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAwsTr, awsRegion, awsBucket, awsAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAwsTr, awsRegion, nettraceFolder, awsBucket, awsAuth)
 	if err == nil && dEndPoint != nil {
 		// create Request
 		req := dEndPoint.NewRequest(operation, "s3teststuff", awsUploadFile, 0, true, respChan)
@@ -121,7 +125,7 @@ func listAwsS3Files(t *testing.T, bucket string) (bool, string) {
 	awsAuth := &zedUpload.AuthInput{AuthType: "password", Uname: key, Password: secret}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAwsTr, awsRegion, bucket, awsAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAwsTr, awsRegion, nettraceFolder, bucket, awsAuth)
 
 	if err == nil && dEndPoint != nil {
 		// create Request
@@ -159,7 +163,7 @@ func getAwsS3ObjectMetaData(t *testing.T, objloc string, objkey string) (bool, s
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAwsTr, awsRegion, awsBucket, awsAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAwsTr, awsRegion, nettraceFolder, awsBucket, awsAuth)
 	if err == nil && dEndPoint != nil {
 		// create Request
 		req := dEndPoint.NewRequest(zedUpload.SyncOpGetObjectMetaData, objkey, objloc, 0, true, respChan)

--- a/zedUpload/datastore_azure_test.go
+++ b/zedUpload/datastore_azure_test.go
@@ -28,6 +28,9 @@ func TestAzureBlobDatastore(t *testing.T) {
 	if err := os.MkdirAll(azureDownloadDir, 0755); err != nil {
 		t.Fatalf("unable to make download directory: %v", err)
 	}
+	if err := os.MkdirAll(nettraceFolder, 0755); err != nil {
+		t.Fatalf("unable to make nettrace log directory: %v", err)
+	}
 	if azureContainer != "" && azureAccountName != "" && azureAccountKey != "" {
 		t.Run("API", testAzureBlobDatastoreAPI)
 		t.Run("Negative", testAzureBlobDatastoreNegative)
@@ -45,7 +48,7 @@ func operationAzureBlob(t *testing.T, objloc string, objkey string, operation ze
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAzureTr, awsRegion, azureContainer, azureAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAzureTr, awsRegion, nettraceFolder, azureContainer, azureAuth)
 	if err == nil && dEndPoint != nil {
 		// create Request
 		req := dEndPoint.NewRequest(operation, objkey, objloc, 0, true, respChan)
@@ -78,7 +81,7 @@ func operationAzureBlobNegative(t *testing.T, azureName string, azureKey string,
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAzureTr, awsRegion, azureContainer, azureAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAzureTr, awsRegion, nettraceFolder, azureContainer, azureAuth)
 	if err == nil && dEndPoint != nil {
 		// create Request
 		req := dEndPoint.NewRequest(operation, "azureteststuff", azureUploadFile, 0, true, respChan)
@@ -111,7 +114,7 @@ func listAzureBlobFiles(t *testing.T, container string) (bool, string) {
 
 	azureAuth := &zedUpload.AuthInput{AuthType: "s3", Uname: azureAccountName, Password: azureAccountKey}
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAzureTr, awsRegion, container, azureAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAzureTr, awsRegion, nettraceFolder, azureContainer, azureAuth)
 
 	if err == nil && dEndPoint != nil {
 
@@ -143,7 +146,7 @@ func getAzureBlobMetaData(t *testing.T, objloc string, objkey string) (bool, str
 		return true, err.Error(), 0, ""
 	}
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAzureTr, awsRegion, azureContainer, azureAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncAzureTr, awsRegion, nettraceFolder, azureContainer, azureAuth)
 	if err == nil && dEndPoint != nil {
 		// create Request
 		req := dEndPoint.NewRequest(zedUpload.SyncOpGetObjectMetaData, objkey, objloc, 0, true, respChan)

--- a/zedUpload/datastore_gs_test.go
+++ b/zedUpload/datastore_gs_test.go
@@ -29,6 +29,9 @@ func TestGSDatastore(t *testing.T) {
 	if err := os.MkdirAll(gsDownloadDir, 0755); err != nil {
 		t.Fatalf("unable to make download directory: %v", err)
 	}
+	if err := os.MkdirAll(nettraceFolder, 0755); err != nil {
+		t.Fatalf("unable to make nettrace log directory: %v", err)
+	}
 	if gsBucket != "" && gsAPIKey != "" && gsProject != "" {
 		t.Run("API", testGSDatastoreAPI)
 		t.Run("Negative", testGSDatastoreNegative)
@@ -46,7 +49,7 @@ func operationGS(t *testing.T, objloc string, objkey string, operation zedUpload
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncGSTr, "", gsBucket, gsAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncGSTr, "", nettraceFolder, gsBucket, gsAuth)
 	if err == nil && dEndPoint != nil {
 		// use custom http client for testing same behaviour as in EVE
 		_ = dEndPoint.WithSrcIP(net.ParseIP("0.0.0.0"))
@@ -85,7 +88,7 @@ func operationGSNegative(t *testing.T, gsProject, gsAPIKey string, operation zed
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncGSTr, "", gsBucket, gsAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncGSTr, "", nettraceFolder, gsBucket, gsAuth)
 	if err == nil && dEndPoint != nil {
 		// create Request
 		req := dEndPoint.NewRequest(operation, "gsteststuff", gsUploadFile, 0, true, respChan)
@@ -123,7 +126,7 @@ func listGSFiles(t *testing.T, bucket string) (bool, string) {
 	gsAuth := &zedUpload.AuthInput{AuthType: "gs", Uname: gsProject, Password: gsAPIKey}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncGSTr, "", bucket, gsAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncGSTr, "", nettraceFolder, bucket, gsAuth)
 
 	if err == nil && dEndPoint != nil {
 		// create Request
@@ -161,7 +164,7 @@ func getGSObjectMetaData(t *testing.T, objloc string, objkey string) (bool, stri
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncGSTr, "", gsBucket, gsAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncGSTr, "", nettraceFolder, gsBucket, gsAuth)
 	if err == nil && dEndPoint != nil {
 		// create Request
 		req := dEndPoint.NewRequest(zedUpload.SyncOpGetObjectMetaData, objkey, objloc, 0, true, respChan)

--- a/zedUpload/datastore_http_test.go
+++ b/zedUpload/datastore_http_test.go
@@ -37,6 +37,9 @@ func TestHTTPDatastore(t *testing.T) {
 	if err := os.MkdirAll(httpDownloadDir, 0755); err != nil {
 		t.Fatalf("unable to make download directory: %v", err)
 	}
+	if err := os.MkdirAll(nettraceFolder, 0755); err != nil {
+		t.Fatalf("unable to make nettrace log directory: %v", err)
+	}
 	t.Run("API", testHTTPDatastoreAPI)
 	t.Run("Negative", testHTTPDatastoreNegative)
 	t.Run("Functional", testHTTPDatastoreFunctional)
@@ -62,7 +65,7 @@ func operationHTTP(l logger, operation zedUpload.SyncOpType, url, remoteDir, rem
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncHttpTr, url, remoteDir, httpAuth, syncerOpts...)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncHttpTr, url, nettraceFolder, remoteDir, httpAuth, syncerOpts...)
 	if err == nil && dEndPoint != nil {
 		if local {
 			var lIP net.IP
@@ -119,7 +122,7 @@ func listHTTPFiles(t *testing.T, url, dir string) (bool, string) {
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncHttpTr, url, dir, httpAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncHttpTr, url, nettraceFolder, dir, httpAuth)
 	if err == nil && dEndPoint != nil {
 		// create Request
 		req := dEndPoint.NewRequest(zedUpload.SyncOpList, "", "", 0, true, respChan)
@@ -153,7 +156,7 @@ func getHTTPObjectMetaData(t *testing.T, objloc string, objkey string, url, dir 
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncHttpTr, url, dir, httpAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncHttpTr, url, nettraceFolder, dir, httpAuth)
 	if err == nil && dEndPoint != nil {
 		// create Request
 		req := dEndPoint.NewRequest(zedUpload.SyncOpGetObjectMetaData, objkey, objloc, 0, true, respChan)

--- a/zedUpload/datastore_sftp_test.go
+++ b/zedUpload/datastore_sftp_test.go
@@ -29,6 +29,9 @@ func TestSFTPDatastore(t *testing.T) {
 	if err := os.MkdirAll(sftpDownloadDir, 0755); err != nil {
 		t.Fatalf("unable to make download directory: %v", err)
 	}
+	if err := os.MkdirAll(nettraceFolder, 0755); err != nil {
+		t.Fatalf("unable to make nettrace log directory: %v", err)
+	}
 	if sftpDir != "" && uname != "" && pass != "" && sftpRegion != "" {
 		t.Run("API", testSFTPDatastoreAPI)
 		t.Run("Negative", testSFTPDatastoreNegative)
@@ -46,7 +49,7 @@ func operationSFTP(t *testing.T, objloc string, objkey string, operation zedUplo
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncSftpTr, sftpRegion, sftpDir, sftpAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncSftpTr, sftpRegion, nettraceFolder, sftpDir, sftpAuth)
 	if err == nil && dEndPoint != nil {
 		// create Request
 		req := dEndPoint.NewRequest(operation, objkey, objloc, 0, true, respChan)
@@ -79,7 +82,7 @@ func operationSFTPNegative(t *testing.T, sftpName string, sftpPass string, opera
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncSftpTr, sftpRegion, sftpDir, sftpAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncSftpTr, sftpRegion, nettraceFolder, sftpDir, sftpAuth)
 	if err == nil && dEndPoint != nil {
 		// create Request
 		req := dEndPoint.NewRequest(operation, "sftpteststuff", sftpUploadFile, 0, true, respChan)
@@ -112,7 +115,7 @@ func listSFTPFiles(t *testing.T, path string) (bool, string) {
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncSftpTr, sftpRegion, path, sftpAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncSftpTr, sftpRegion, nettraceFolder, path, sftpAuth)
 	if err == nil && dEndPoint != nil {
 		// create Request
 		req := dEndPoint.NewRequest(zedUpload.SyncOpList, "", "", 0, true, respChan)
@@ -145,7 +148,7 @@ func getSFTPObjectMetaData(t *testing.T, objloc string, objkey string) (bool, st
 	}
 
 	// create Endpoint
-	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncSftpTr, sftpRegion, sftpDir, sftpAuth)
+	dEndPoint, err := ctx.NewSyncerDest(zedUpload.SyncSftpTr, sftpRegion, nettraceFolder, sftpDir, sftpAuth)
 	if err == nil && dEndPoint != nil {
 		// create Request
 		req := dEndPoint.NewRequest(zedUpload.SyncOpGetObjectMetaData, objkey, objloc, 0, true, respChan)


### PR DESCRIPTION
…ading to the disk.

This commit optimizes memory usage in nettrace by storing only a limited number of network metadata entries in memory. When a defined threshold is exceeded, additional metadata is written to DB for persistence. This balances performance and resource usage, especially under high network activity.