### PR TITLE
github/workflows: Add Azure and AWS secrets and variables

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,11 @@ jobs:
     env:
         GOOS: ${{ matrix.target.os }}
         GOARCH: ${{ matrix.target.arch }}
+        TEST_AZURE_ACCOUNT_URL: ${{ secrets.TEST_AZURE_ACCOUNT_URL }}
+        TEST_AZURE_ACCOUNT_NAME: ${{ secrets.TEST_AZURE_ACCOUNT_NAME }}
+        TEST_AZURE_ACCOUNT_KEY: ${{ secrets.TEST_AZURE_ACCOUNT_KEY }}
+        TEST_AZURE_CONTAINER: ${{ vars.TEST_AZURE_CONTAINER }}
+        TEST_AZURE_BLOB_PREFIX: ${{ vars.TEST_AZURE_BLOB_PREFIX }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,10 @@ jobs:
         TEST_AZURE_ACCOUNT_KEY: ${{ secrets.TEST_AZURE_ACCOUNT_KEY }}
         TEST_AZURE_CONTAINER: ${{ vars.TEST_AZURE_CONTAINER }}
         TEST_AZURE_BLOB_PREFIX: ${{ vars.TEST_AZURE_BLOB_PREFIX }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: ${{ vars.AWS_REGION }}
+        AWS_TEST_BUCKET: ${{ vars.AWS_TEST_BUCKET }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout


### PR DESCRIPTION
# Description

This PR handles environment variables for automated tests for Azue and AWS Libraries.

## AWS

github/workflows: Add AWS secrets and variables
    
the tests for AWS library expects the following environment variables to use an AWS datastore:
    
1. AWS_ACCESS_KEY_ID
1. AWS_SECRET_ACCESS_KEY
1. AWS_REGION
1. AWS_TEST_BUCKET
    
1 and 2 are expected to be secrets while 3 and 4 are expected to be simple variables. This commit exposes all of them to the build workflow.

## Azure

The tests for Azure library expects the following environment variables to use an Azure datastore:

1. TEST_AZURE_ACCOUNT_URL
1. TEST_AZURE_ACCOUNT_NAME
1. TEST_AZURE_ACCOUNT_KEY
1. TEST_AZURE_CONTAINER
1. TEST_AZURE_BLOB_PREFIX

1, 2, and 3 are expected to be secrets while 4 and 5 are expected to be simple variables. This commit exposes all of them to the build workflow.