### PR TITLE
Fixed TestTLSCertErrors test

### DIFF
--- a/nettrace/httpclient_test.go
+++ b/nettrace/httpclient_test.go
@@ -426,9 +426,7 @@ func TestTLSCertErrors(test *testing.T) {
 	t.Expect(tlsTun.PeerCerts).To(HaveLen(1))
 	peerCert = tlsTun.PeerCerts[0]
 	t.Expect(peerCert.IsCA).To(BeFalse())
-	t.Expect(peerCert.Issuer).To(SatisfyAny(
-		Equal("CN=R10,O=Let's Encrypt,C=US"),
-		Equal("CN=R11,O=Let's Encrypt,C=US")))
+	t.Expect(peerCert.Issuer).To(MatchRegexp(`^CN=R\d{1,2},O=Let's Encrypt,C=US$`))
 	t.Expect(peerCert.Subject).To(Equal("CN=*.badssl.com"))
 	t.Expect(peerCert.NotBefore.Abs.Before(time.Now())).To(BeTrue())
 	t.Expect(peerCert.NotAfter.Abs.After(time.Now())).To(BeTrue())


### PR DESCRIPTION
This PR fixes the unit test in nettrace when checking TLSCertErrors