### PR TITLE
[16.0-stable] nettrace: flush and wait for batch offload before returning from GetTrace

### DIFF
--- a/nettrace/httpclient.go
+++ b/nettrace/httpclient.go
@@ -93,6 +93,7 @@ type HTTPClient struct {
 	// Network tracing
 	nfConn           *conntrack.Conn
 	tracingWG        sync.WaitGroup
+	batchWG          sync.WaitGroup
 	tracingCtx       context.Context
 	cancelTracing    context.CancelFunc
 	tracingStartedAt Timestamp
@@ -644,6 +645,10 @@ func (c *HTTPClient) GetTrace(description string) (HTTPTrace, []PacketCapture, e
 	// If we are in batch-offload mode, do NOT aggregate in-memory maps.
 	// The consumer should export JSON from the Bolt sink with this meta.
 	if c.batchCb != nil {
+		// Offload any remaining traces and wait for all asynchronous
+		// batch callbacks to complete before returning.
+		c.flushAllLocked()
+		c.batchWG.Wait()
 		return httpTrace, pcaps, nil
 	}
 
@@ -1045,7 +1050,11 @@ func (c *HTTPClient) flushIfThresholdLocked() {
 		return
 	}
 	cb := c.batchCb
-	go cb(snap)
+	c.batchWG.Add(1)
+	go func() {
+		cb(snap)
+		c.batchWG.Done()
+	}()
 }
 
 // flushAllLocked emits all remaining items (used on Close when enabled).
@@ -1118,7 +1127,11 @@ func (c *HTTPClient) flushAllLocked() {
 		return
 	}
 	cb := c.batchCb
-	go cb(snap)
+	c.batchWG.Add(1)
+	go func() {
+		cb(snap)
+		c.batchWG.Done()
+	}()
 }
 
 // processPendingTraces : processes all currently pending network traces.

--- a/nettrace/httpclient_test.go
+++ b/nettrace/httpclient_test.go
@@ -580,7 +580,7 @@ func TestHTTPTracing(test *testing.T) {
 	peerCert := tlsTun.PeerCerts[0]
 	t.Expect(peerCert.IsCA).To(BeFalse())
 	t.Expect(peerCert.Subject).To(Equal("CN=example.com"))
-	t.Expect(peerCert.Issuer).To(Equal("CN=Cloudflare TLS Issuing ECC CA 3,O=SSL Corporation,C=US"))
+	t.Expect(peerCert.Issuer).To(Equal("CN=Cloudflare TLS Issuing ECC CA 1,O=CLOUDFLARE\\, INC.,C=US"))
 	t.Expect(peerCert.NotBefore.Undefined()).To(BeFalse())
 	t.Expect(peerCert.NotBefore.IsRel).To(BeFalse())
 	t.Expect(peerCert.NotAfter.Undefined()).To(BeFalse())
@@ -589,7 +589,7 @@ func TestHTTPTracing(test *testing.T) {
 	t.Expect(peerCert.NotAfter.Abs.After(time.Now())).To(BeTrue())
 	peerCert = tlsTun.PeerCerts[1]
 	t.Expect(peerCert.IsCA).To(BeTrue())
-	t.Expect(peerCert.Subject).To(Equal("CN=Cloudflare TLS Issuing ECC CA 3,O=SSL Corporation,C=US"))
+	t.Expect(peerCert.Subject).To(Equal("CN=Cloudflare TLS Issuing ECC CA 1,O=CLOUDFLARE\\, INC.,C=US"))
 	t.Expect(peerCert.Issuer).To(Equal("CN=SSL.com TLS Transit ECC CA R2,O=SSL Corporation,C=US"))
 	t.Expect(peerCert.NotBefore.Undefined()).To(BeFalse())
 	t.Expect(peerCert.NotBefore.IsRel).To(BeFalse())

--- a/nettrace/httpclient_test.go
+++ b/nettrace/httpclient_test.go
@@ -576,7 +576,7 @@ func TestHTTPTracing(test *testing.T) {
 	t.Expect(tlsTun.ServerName).To(Equal("www.example.com"))
 	t.Expect(tlsTun.NegotiatedProto).To(Equal("h2"))
 	t.Expect(tlsTun.CipherSuite).ToNot(BeZero())
-	t.Expect(tlsTun.PeerCerts).To(HaveLen(4))
+	t.Expect(tlsTun.PeerCerts).To(HaveLen(3))
 	peerCert := tlsTun.PeerCerts[0]
 	t.Expect(peerCert.IsCA).To(BeFalse())
 	t.Expect(peerCert.Subject).To(Equal("CN=example.com"))
@@ -600,16 +600,6 @@ func TestHTTPTracing(test *testing.T) {
 	peerCert = tlsTun.PeerCerts[2]
 	t.Expect(peerCert.IsCA).To(BeTrue())
 	t.Expect(peerCert.Subject).To(Equal("CN=SSL.com TLS Transit ECC CA R2,O=SSL Corporation,C=US"))
-	t.Expect(peerCert.Issuer).To(Equal("CN=SSL.com TLS ECC Root CA 2022,O=SSL Corporation,C=US"))
-	t.Expect(peerCert.NotBefore.Undefined()).To(BeFalse())
-	t.Expect(peerCert.NotBefore.IsRel).To(BeFalse())
-	t.Expect(peerCert.NotAfter.Undefined()).To(BeFalse())
-	t.Expect(peerCert.NotAfter.IsRel).To(BeFalse())
-	t.Expect(peerCert.NotBefore.Abs.Before(time.Now())).To(BeTrue())
-	t.Expect(peerCert.NotAfter.Abs.After(time.Now())).To(BeTrue())
-	peerCert = tlsTun.PeerCerts[3]
-	t.Expect(peerCert.IsCA).To(BeTrue())
-	t.Expect(peerCert.Subject).To(Equal("CN=SSL.com TLS ECC Root CA 2022,O=SSL Corporation,C=US"))
 	t.Expect(peerCert.Issuer).To(Equal("CN=AAA Certificate Services,O=Comodo CA Limited,L=Salford,ST=Greater Manchester,C=GB"))
 	t.Expect(peerCert.NotBefore.Undefined()).To(BeFalse())
 	t.Expect(peerCert.NotBefore.IsRel).To(BeFalse())


### PR DESCRIPTION
Ensure that HTTPClient.GetTrace flushes all in-memory traces and waits for all asynchronously offloaded batches to complete before returning.

Previously, when batch-offload mode was enabled, flush callbacks were invoked in separate goroutines but GetTrace could return before those callbacks finished. In addition, traces still buffered inside in-memory evicting maps might not have been flushed to the sink yet.

Since callers expect that, after GetTrace returns, offloaded data can be immediately exported (e.g. via BoltBatchSink.ExportToJSON or other sink implementations), GetTrace must guarantee that:

  - All in-memory traces are flushed to the batch sink.
  - All asynchronous batch callbacks have completed.

Introduce a dedicated sync.WaitGroup (batchWG) to track in-flight batch offload callbacks. Increment the counter before launching each callback goroutine and decrement it upon completion. In GetTrace, call flushAllLocked() to emit any remaining traces and then wait for batchWG to reach zero before returning.

This guarantees that all captured traces are fully flushed and persisted prior to export, preventing loss of the final trace batches.

(cherry picked from commit cd723e7c57cb3acef734d5ff391b039387258c28)