### PR TITLE
[16.0-stable]: zedUpload: robust path joining for SFTP, OCI and HTTP // download url with query params

### DIFF
--- a/zedUpload/datastore_http.go
+++ b/zedUpload/datastore_http.go
@@ -153,13 +153,9 @@ func (ep *HttpTransportMethod) processHttpUpload(req *DronaRequest) (error, int)
 
 // File download from HTTP Datastore
 func (ep *HttpTransportMethod) processHttpDownload(req *DronaRequest) (error, int) {
-	file := req.name
-	if ep.hurl != "" {
-		var err error
-		file, err = url.JoinPath(ep.hurl, ep.path, req.name)
-		if err != nil {
-			return err, 0
-		}
+	file, err := ep.concatenateFile(req)
+	if err != nil {
+		return err, 0
 	}
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
@@ -176,6 +172,25 @@ func (ep *HttpTransportMethod) processHttpDownload(req *DronaRequest) (error, in
 		req.objloc, req.sizelimit, prgChan, doneParts, hClient, ep.inactivityTimeout,
 		ep.buildAuthHeader())
 	return stats.Error, resp.BodyLength
+}
+
+func (ep *HttpTransportMethod) concatenateFile(req *DronaRequest) (string, error) {
+	file := req.name
+	if ep.hurl != "" {
+		var err error
+		file, err = url.JoinPath(ep.hurl, ep.path)
+		if err != nil {
+			return "", err
+		}
+
+		file = strings.TrimSuffix(file, "/")
+		reqName := req.name
+		for strings.HasPrefix(reqName, "/") {
+			reqName = strings.TrimPrefix(reqName, "/")
+		}
+		file += "/" + reqName
+	}
+	return file, nil
 }
 
 // File delete from HTTP Datastore
@@ -208,14 +223,11 @@ func (ep *HttpTransportMethod) processHttpList(req *DronaRequest) ([]string, err
 
 // Object Metadata from HTTP datastore
 func (ep *HttpTransportMethod) processHttpObjectMetaData(req *DronaRequest) (error, int64) {
-	file := req.name
-	if ep.hurl != "" {
-		var err error
-		file, err = url.JoinPath(ep.hurl, ep.path, req.name)
-		if err != nil {
-			return err, 0
-		}
+	file, err := ep.concatenateFile(req)
+	if err != nil {
+		return err, 0
 	}
+
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {

--- a/zedUpload/datastore_http.go
+++ b/zedUpload/datastore_http.go
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2018 Zededa, Inc.
+// Copyright(c) 2017-2026 Zededa, Inc.
 // All rights reserved.
 
 package zedUpload
@@ -130,7 +130,10 @@ func (ep *HttpTransportMethod) GetNetTrace(description string) (
 
 // File upload to HTTP Datastore
 func (ep *HttpTransportMethod) processHttpUpload(req *DronaRequest) (error, int) {
-	postUrl := ep.hurl + "/" + ep.path
+	postUrl, err := url.JoinPath(ep.hurl, ep.path)
+	if err != nil {
+		return err, 0
+	}
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {
@@ -152,7 +155,11 @@ func (ep *HttpTransportMethod) processHttpUpload(req *DronaRequest) (error, int)
 func (ep *HttpTransportMethod) processHttpDownload(req *DronaRequest) (error, int) {
 	file := req.name
 	if ep.hurl != "" {
-		file = ep.hurl + "/" + ep.path + "/" + req.name
+		var err error
+		file, err = url.JoinPath(ep.hurl, ep.path, req.name)
+		if err != nil {
+			return err, 0
+		}
 	}
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
@@ -178,7 +185,10 @@ func (ep *HttpTransportMethod) processHttpDelete(req *DronaRequest) error {
 
 // File list from HTTP Datastore
 func (ep *HttpTransportMethod) processHttpList(req *DronaRequest) ([]string, error) {
-	listUrl := ep.hurl + "/" + ep.path
+	listUrl, err := url.JoinPath(ep.hurl, ep.path)
+	if err != nil {
+		return nil, err
+	}
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {
@@ -200,7 +210,11 @@ func (ep *HttpTransportMethod) processHttpList(req *DronaRequest) ([]string, err
 func (ep *HttpTransportMethod) processHttpObjectMetaData(req *DronaRequest) (error, int64) {
 	file := req.name
 	if ep.hurl != "" {
-		file = ep.hurl + "/" + ep.path + "/" + req.name
+		var err error
+		file, err = url.JoinPath(ep.hurl, ep.path, req.name)
+		if err != nil {
+			return err, 0
+		}
 	}
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)

--- a/zedUpload/datastore_http_url_test.go
+++ b/zedUpload/datastore_http_url_test.go
@@ -1,0 +1,211 @@
+// Copyright(c) 2026 Zededa, Inc.
+// All rights reserved.
+
+package zedUpload_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve-libs/zedUpload"
+)
+
+// TestHTTPURLConstruction verifies that URLs are constructed correctly
+// using url.JoinPath, avoiding double slashes or missing slashes.
+func TestHTTPURLConstruction(t *testing.T) {
+	var receivedPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		// Return some dummy content so downloads don't fail immediately on Body read
+		_, err := w.Write([]byte("some data"))
+		if err != nil {
+			t.Fatalf("Failed to write response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	serverURL := ts.URL
+
+	tests := []struct {
+		name           string
+		remoteDir      string
+		remoteFilename string
+		operation      zedUpload.SyncOpType
+		expectedPath   string
+	}{
+		// Download Tests (URL = serverURL + remoteDir + remoteFilename)
+		{
+			name:           "Download: Normal",
+			remoteDir:      "folder",
+			remoteFilename: "file.txt",
+			operation:      zedUpload.SyncOpDownload,
+			expectedPath:   "/folder/file.txt",
+		},
+		{
+			name:           "Download: Empty dir",
+			remoteDir:      "",
+			remoteFilename: "file.txt",
+			operation:      zedUpload.SyncOpDownload,
+			expectedPath:   "/file.txt",
+		},
+		{
+			name:           "Download: Dir with trailing slash",
+			remoteDir:      "folder/",
+			remoteFilename: "file.txt",
+			operation:      zedUpload.SyncOpDownload,
+			expectedPath:   "/folder/file.txt",
+		},
+		{
+			name:           "Download: Dir with leading slash",
+			remoteDir:      "/folder",
+			remoteFilename: "file.txt",
+			operation:      zedUpload.SyncOpDownload,
+			expectedPath:   "/folder/file.txt",
+		},
+		{
+			name:           "Download: Filename with leading slash",
+			remoteDir:      "folder",
+			remoteFilename: "/file.txt",
+			operation:      zedUpload.SyncOpDownload,
+			expectedPath:   "/folder/file.txt",
+		},
+		{
+			name:           "Download: Empty dir, filename with slash",
+			remoteDir:      "",
+			remoteFilename: "/file.txt",
+			operation:      zedUpload.SyncOpDownload,
+			expectedPath:   "/file.txt",
+		},
+		// Upload Tests (URL = serverURL + remoteDir)
+		{
+			name:           "Upload: Normal",
+			remoteDir:      "upload",
+			remoteFilename: "data.bin",
+			operation:      zedUpload.SyncOpUpload,
+			expectedPath:   "/upload",
+		},
+		{
+			name:           "Upload: Empty dir",
+			remoteDir:      "",
+			remoteFilename: "data.bin",
+			operation:      zedUpload.SyncOpUpload,
+			expectedPath:   "/",
+		},
+		{
+			name:           "Upload: Dir with trailing slash",
+			remoteDir:      "upload/",
+			remoteFilename: "data.bin",
+			operation:      zedUpload.SyncOpUpload,
+			expectedPath:   "/upload/",
+		},
+		// List Tests (URL = serverURL + remoteDir)
+		{
+			name:           "List: Normal",
+			remoteDir:      "images",
+			remoteFilename: "",
+			operation:      zedUpload.SyncOpList,
+			expectedPath:   "/images",
+		},
+		{
+			name:           "List: Empty dir",
+			remoteDir:      "",
+			remoteFilename: "",
+			operation:      zedUpload.SyncOpList,
+			expectedPath:   "/",
+		},
+		// MetaData Tests (URL = serverURL + remoteDir + remoteFilename)
+		{
+			name:           "MetaData: Normal",
+			remoteDir:      "meta",
+			remoteFilename: "image.img",
+			operation:      zedUpload.SyncOpGetObjectMetaData,
+			expectedPath:   "/meta/image.img",
+		},
+		{
+			name:           "MetaData: Empty dir",
+			remoteDir:      "",
+			remoteFilename: "image.img",
+			operation:      zedUpload.SyncOpGetObjectMetaData,
+			expectedPath:   "/image.img",
+		},
+		{
+			name:           "MetaData: Dir with trailing slash",
+			remoteDir:      "meta/",
+			remoteFilename: "image.img",
+			operation:      zedUpload.SyncOpGetObjectMetaData,
+			expectedPath:   "/meta/image.img",
+		},
+		{
+			name:           "MetaData: Filename with leading slash",
+			remoteDir:      "meta",
+			remoteFilename: "/image.img",
+			operation:      zedUpload.SyncOpGetObjectMetaData,
+			expectedPath:   "/meta/image.img",
+		},
+	}
+
+	tmpDir := t.TempDir()
+	// Create a dummy local file for upload
+	localFile := filepath.Join(tmpDir, "dummy_local")
+	if err := os.WriteFile(localFile, []byte("test content"), 0644); err != nil {
+		t.Fatalf("Failed to create dummy local file: %v", err)
+	}
+	// For download destination
+	// We need to make sure we don't overwrite the upload source if we use same var,
+	// but here we use localFile as source for Upload and destination for Download.
+	// That's fine.
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			receivedPath = ""
+
+			httpAuth := &zedUpload.AuthInput{AuthType: "http"}
+			ctx, err := zedUpload.NewDronaCtx("test-url-constr", 0)
+			if ctx == nil || err != nil {
+				t.Fatalf("NewDronaCtx failed: %v", err)
+			}
+			// defer ctx.Close()
+
+			// Create Endpoint
+			ep, err := ctx.NewSyncerDest(zedUpload.SyncHttpTr, serverURL, tmpDir, tt.remoteDir, httpAuth)
+			if err != nil {
+				t.Fatalf("NewSyncerDest failed: %v", err)
+			}
+
+			respChan := make(chan *zedUpload.DronaRequest)
+
+			req := ep.NewRequest(tt.operation, tt.remoteFilename, localFile, 0, true, respChan)
+			if req == nil {
+				t.Fatalf("NewRequest returned nil")
+			}
+
+			if err := req.Post(); err != nil {
+				t.Fatalf("req.Post() failed: %v", err)
+			}
+
+			// Wait for response
+			timeout := time.After(2 * time.Second)
+			done := false
+			for !done {
+				select {
+				case resp := <-respChan:
+					if !resp.IsDnUpdate() {
+						done = true
+					}
+				case <-timeout:
+					t.Fatalf("Timed out waiting for operation")
+				}
+			}
+
+			// Check path
+			if receivedPath != tt.expectedPath {
+				t.Errorf("Path mismatch.\nExpected: %q\nGot:      %q", tt.expectedPath, receivedPath)
+			}
+		})
+	}
+}

--- a/zedUpload/datastore_http_url_test.go
+++ b/zedUpload/datastore_http_url_test.go
@@ -6,8 +6,10 @@ package zedUpload_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -17,9 +19,9 @@ import (
 // TestHTTPURLConstruction verifies that URLs are constructed correctly
 // using url.JoinPath, avoiding double slashes or missing slashes.
 func TestHTTPURLConstruction(t *testing.T) {
-	var receivedPath string
+	receivedPathChan := make(chan *http.Request)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		receivedPath = r.URL.Path
+		receivedPathChan <- r
 		w.WriteHeader(http.StatusOK)
 		// Return some dummy content so downloads don't fail immediately on Body read
 		_, err := w.Write([]byte("some data"))
@@ -32,11 +34,12 @@ func TestHTTPURLConstruction(t *testing.T) {
 	serverURL := ts.URL
 
 	tests := []struct {
-		name           string
-		remoteDir      string
-		remoteFilename string
-		operation      zedUpload.SyncOpType
-		expectedPath   string
+		name            string
+		remoteDir       string
+		remoteFilename  string
+		operation       zedUpload.SyncOpType
+		expectedPath    string
+		expectedQueries url.Values
 	}{
 		// Download Tests (URL = serverURL + remoteDir + remoteFilename)
 		{
@@ -73,6 +76,17 @@ func TestHTTPURLConstruction(t *testing.T) {
 			remoteFilename: "/file.txt",
 			operation:      zedUpload.SyncOpDownload,
 			expectedPath:   "/folder/file.txt",
+		},
+		{
+			name:           "Download: Filename with query parameters",
+			remoteDir:      "folder",
+			remoteFilename: "/file.txt?foo=bar&bar=baz",
+			operation:      zedUpload.SyncOpDownload,
+			expectedPath:   "/folder/file.txt",
+			expectedQueries: url.Values{
+				"foo": []string{"bar"},
+				"bar": []string{"baz"},
+			},
 		},
 		{
 			name:           "Download: Empty dir, filename with slash",
@@ -162,7 +176,6 @@ func TestHTTPURLConstruction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			receivedPath = ""
 
 			httpAuth := &zedUpload.AuthInput{AuthType: "http"}
 			ctx, err := zedUpload.NewDronaCtx("test-url-constr", 0)
@@ -188,6 +201,7 @@ func TestHTTPURLConstruction(t *testing.T) {
 				t.Fatalf("req.Post() failed: %v", err)
 			}
 
+			receivedReq := <-receivedPathChan
 			// Wait for response
 			timeout := time.After(2 * time.Second)
 			done := false
@@ -202,9 +216,12 @@ func TestHTTPURLConstruction(t *testing.T) {
 				}
 			}
 
+			if tt.expectedQueries != nil && !reflect.DeepEqual(tt.expectedQueries, receivedReq.URL.Query()) {
+				t.Fatalf("expected queries: %+v, got: %+v", tt.expectedQueries, receivedReq.URL.Query())
+			}
 			// Check path
-			if receivedPath != tt.expectedPath {
-				t.Errorf("Path mismatch.\nExpected: %q\nGot:      %q", tt.expectedPath, receivedPath)
+			if receivedReq.URL.Path != tt.expectedPath {
+				t.Errorf("Path mismatch.\nExpected: %q\nGot:      %q", tt.expectedPath, receivedReq.URL.Path)
 			}
 		})
 	}

--- a/zedUpload/datastore_sftp_internal_test.go
+++ b/zedUpload/datastore_sftp_internal_test.go
@@ -1,0 +1,64 @@
+// Copyright(c) 2026 Zededa, Inc.
+// All rights reserved.
+
+package zedUpload
+
+import (
+	"testing"
+)
+
+func TestSftpResolvePath(t *testing.T) {
+	tests := []struct {
+		name         string
+		basePath     string
+		fileName     string
+		expectedPath string
+	}{
+		{
+			name:         "clean join",
+			basePath:     "/home/user",
+			fileName:     "file.txt",
+			expectedPath: "/home/user/file.txt",
+		},
+		{
+			name:         "trailing slash in base",
+			basePath:     "/home/user/",
+			fileName:     "file.txt",
+			expectedPath: "/home/user/file.txt",
+		},
+		{
+			name:         "leading slash in file",
+			basePath:     "/home/user",
+			fileName:     "/file.txt",
+			expectedPath: "/home/user/file.txt",
+		},
+		{
+			name:         "both slashes",
+			basePath:     "/home/user/",
+			fileName:     "/file.txt",
+			expectedPath: "/home/user/file.txt",
+		},
+		{
+			name:         "empty base",
+			basePath:     "",
+			fileName:     "file.txt",
+			expectedPath: "file.txt",
+		},
+		{
+			name:         "relative base",
+			basePath:     "uploads",
+			fileName:     "image.png",
+			expectedPath: "uploads/image.png",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := &SftpTransportMethod{path: tt.basePath}
+			result := ep.resolvePath(tt.fileName)
+			if result != tt.expectedPath {
+				t.Errorf("expected %q, got %q", tt.expectedPath, result)
+			}
+		})
+	}
+}

--- a/zedUpload/ociutil/oci.go
+++ b/zedUpload/ociutil/oci.go
@@ -1,3 +1,6 @@
+// Copyright(c) 2017-2026 Zededa, Inc.
+// All rights reserved.
+
 package ociutil
 
 import (
@@ -28,7 +31,7 @@ func Tags(registry, repository, username, apiKey string, client *http.Client, pr
 	var (
 		tags  []string
 		err   error
-		image = fmt.Sprintf("%s/%s", registry, repository)
+		image = path.Join(registry, repository)
 	)
 
 	repo, err := name.NewRepository(image)
@@ -82,7 +85,7 @@ func PullBlob(registry, repo, hash, localFile, username, apiKey string, maxsize 
 
 	// The OCI distribution spec only uses /blobs/ endpoint for layers or config, not index or manifest.
 	// I have no idea why you cannot get a manifest or index from the /blobs endpoint, but so be it.
-	image := fmt.Sprintf("%s/%s", registry, repo)
+	image := path.Join(registry, repo)
 	ref, err := name.ParseReference(image)
 	if err != nil {
 		return 0, "", fmt.Errorf("parsing reference %q: %v", image, err)


### PR DESCRIPTION
seems https://github.com/lf-edge/eve-libs/pull/59/commits was missing in 16.0-stable, so I added it

this is a backport of https://github.com/lf-edge/eve-libs/pull/76


depends on https://github.com/lf-edge/eve-libs/pull/79 (for running the tests successfully)