### PR TITLE
zedUpload: allow source-IP-bound HTTP client to use loopback DNS servers

### DIFF
--- a/zedUpload/commonutils.go
+++ b/zedUpload/commonutils.go
@@ -180,6 +180,11 @@ func (c *httpClientWrapper) unwrap() (*http.Client, error) {
 				localTCPAddr := &net.TCPAddr{IP: c.srcIP}
 				localUDPAddr := &net.UDPAddr{IP: c.srcIP}
 				resolverDial := func(ctx context.Context, network, address string) (net.Conn, error) {
+					// Skip source IP binding for loopback DNS servers.
+					host, _, _ := net.SplitHostPort(address)
+					if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+						return (&net.Dialer{}).DialContext(ctx, network, address)
+					}
 					switch network {
 					case "udp", "udp4", "udp6":
 						d := net.Dialer{LocalAddr: localUDPAddr}


### PR DESCRIPTION
When an HTTP client is configured with a source IP, the resolver dial function binds both UDP and TCP connections to that source IP. This prevents reaching DNS servers listening on loopback addresses (e.g. `127.0.0.1`), because the kernel rejects binding a non-loopback source address for connections to a loopback destination.

Skip source IP binding when the DNS server address is a loopback IP so that the resolver can reach it regardless of the configured source IP.

This small enhancement is a prerequisite for: https://github.com/lf-edge/eve/pull/6021